### PR TITLE
Fix import mounts and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The icons gets mounted in `assets/svg/heroicons`.
 This means that they can be used like this in a Hugo template:
 
 ```html
-{{ $icon := resources.Get "svg/heroicons/outline-md/md-search.svg" }}
+{{ $icon := resources.Get "svg/heroicons/outline/search.svg" }}
 {{ $icon.Content | safeHTML }}
 ```
 

--- a/config.toml
+++ b/config.toml
@@ -2,5 +2,5 @@
 [[module.imports]]
 path="github.com/refactoringui/heroicons"
 [[module.imports.mounts]]
-source = "dist"
+source = "src"
 target = "assets/svg/heroicons"


### PR DESCRIPTION
That PR follow off Github conversation with @yaaax about using that module and fixes dist and example in the readme.

Looking at 0.3.2 tag of hericons, `dist` directory don't exist anymore and `svg` names and directories have changed.

